### PR TITLE
exclude build/_output from the license check

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -134,7 +134,7 @@ tidy: test ; $(info $(M) modules tidy...) @ ## Common run test before and after 
 .PHONY: license_check
 license_check: ; $(info $(M) running license check...) @ ## Common examine and ensure license headers exist
 	$Q @if [ ! -d "../build-tools" ]; then cd .. && git clone https://github.com/onosproject/build-tools.git; fi
-	$Q ./../build-tools/licensing/boilerplate.py -v --rootdir=$(CURDIR)
+	$Q ./../build-tools/licensing/boilerplate.py -v --rootdir=$(CURDIR) --skipped-dir=build/_output
 
 # Misc
 


### PR DESCRIPTION
leveraging the change I made to build tools license check https://github.com/onosproject/build-tools/issues/8 